### PR TITLE
feat: support generate snippet location

### DIFF
--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ import (
 
 var pkg = flag.String("pkg", "generated", "generated package name")
 var dir = flag.String("dir", ".", "source code dir to scan examples")
+var relBase = flag.String("rel-base", ".", "the path on which the file of the snippet result is based for filepath.Rel")
 var sdirs = flag.String("skip-dir", "", "comma separate dirs to skip like '.git/,node_modules/'")
 
 var skipDirs = []string{
@@ -31,9 +32,19 @@ func main() {
 		}
 	}
 
+	var err error
+	var relBaseAbs string
+	if *relBase != "" {
+		relBaseAbs, err = filepath.Abs(*relBase)
+		if err != nil {
+			panic(err)
+		}
+	}
+
 	gf := gogen.File("f.go").Package(*pkg)
 
-	err := filepath.Walk(*dir, func(path string, f os.FileInfo, err error) error {
+	imported := false
+	err = filepath.Walk(*dir, func(path string, f os.FileInfo, err error) error {
 
 		for _, dir := range skipDirs {
 			if strings.Index(path, dir) >= 0 {
@@ -58,8 +69,38 @@ func main() {
 			fmt.Fprint(os.Stderr, err)
 		}
 
+		if len(snippets) > 0 && !imported {
+			gf.Body(
+				gogen.Imports(
+					"github.com/sunfmin/snippetgo/parse",
+				),
+			)
+			imported = true
+		}
+
 		for _, s := range snippets {
-			gf.BodySnippet("var $NAME = string($BYTE)", "$NAME", s.Name, "$BYTE", fmt.Sprintf("%#+v", []byte(s.Code)))
+			locationFile, err := filepath.Abs(s.Location.File)
+			if err != nil {
+				return err
+			}
+			if relBaseAbs != "" {
+				relPath, err := filepath.Rel(relBaseAbs, locationFile)
+				if err != nil {
+					return fmt.Errorf("filepath.Rel err: %w", err)
+				}
+				locationFile = relPath
+			}
+
+			gf.BodySnippet(`
+var $NAME = string($BYTE)
+var $NAMELocation = parse.Location{File: $FILE, StartLine: $START, EndLine: $END}
+`,
+				"$NAME", s.Name,
+				"$BYTE", fmt.Sprintf("%#+v", []byte(s.Code)),
+				"$FILE", fmt.Sprintf("%q", locationFile),
+				"$START", fmt.Sprint(s.Location.StartLine),
+				"$END", fmt.Sprint(s.Location.EndLine),
+			)
 		}
 
 		return nil

--- a/parse/parse.go
+++ b/parse/parse.go
@@ -7,9 +7,15 @@ import (
 	"strings"
 )
 
+type Location struct {
+	File               string
+	StartLine, EndLine int
+}
+
 type Snippet struct {
-	Name string
-	Code string
+	Name     string
+	Code     string
+	Location Location
 }
 
 type stackElement struct {
@@ -44,7 +50,13 @@ func Snippets(file string) (r []*Snippet, err error) {
 		if name, ok := snippetName(c); ok {
 			stack = append(stack, &stackElement{
 				startIndex: i,
-				snippet:    &Snippet{Name: name},
+				snippet: &Snippet{
+					Name: name,
+					Location: Location{
+						File:      file,
+						StartLine: i + 1,
+					},
+				},
 			})
 		}
 
@@ -59,6 +71,7 @@ func Snippets(file string) (r []*Snippet, err error) {
 					),
 					"\n",
 				)
+				last.snippet.Location.EndLine = i + 1
 				r = append(r, last.snippet)
 				stack = stack[0 : len(stack)-1]
 			} else {

--- a/parse/parse_test.go
+++ b/parse/parse_test.go
@@ -23,6 +23,11 @@ func TestAll(t *testing.T) {
 				{
 					Name: "Helloworldprint",
 					Code: `fmt.Println(c)`,
+					Location: parse.Location{
+						File:      "./fixtures/simple.go",
+						StartLine: 11,
+						EndLine:   13,
+					},
 				},
 				{
 					Name: "Helloworld",
@@ -30,6 +35,11 @@ func TestAll(t *testing.T) {
 for _, c := range "Hello" {
 	fmt.Println(c)
 }`,
+					Location: parse.Location{
+						File:      "./fixtures/simple.go",
+						StartLine: 8,
+						EndLine:   15,
+					},
 				},
 			},
 		},
@@ -47,6 +57,11 @@ for _, c := range "Hello" {
 },
 
 props: ['value'],`,
+					Location: parse.Location{
+						File:      "./fixtures/hello.js",
+						StartLine: 3,
+						EndLine:   11,
+					},
 				},
 			},
 		},


### PR DESCRIPTION
- support generate snippet location
- flag `rel-base` is used to prevent sensitive paths from being exposed